### PR TITLE
Fix fatal error in PHP 8.0

### DIFF
--- a/simplei.module
+++ b/simplei.module
@@ -28,7 +28,7 @@ function simplei_init() {
         'simplei' => array(
           'addFavicon' => TRUE,
           // Get the first letter out of the name.
-          'faviconLabel' => $indicator[1]{0},
+          'faviconLabel' => $indicator[1][0],
           'faviconColor' => $indicator[0],
           'faviconTextColor' => '#ffffff',
         ),


### PR DESCRIPTION
Curly brace syntax for accessing array elements and string offsets has been deprecated in PHP 7.4.